### PR TITLE
feat:Update OpenAPI specification version from 0.1.98 to 0.1.99

### DIFF
--- a/src/libs/Jina/openapi.yaml
+++ b/src/libs/Jina/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: The Jina Embedding Serving API
   description: This is the UniversalAPI to access all the Jina embedding models
-  version: 0.1.98
+  version: 0.1.99
 servers:
   - url: https://api.jina.ai/
 paths:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the OpenAPI specification version for the Jina Embedding Serving API to `0.1.99`.
  
- **Deprecations**
	- The `/v1/multi-embeddings` endpoint has been marked as deprecated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->