### PR TITLE
feat:Update OpenAPI grounding endpoint operation IDs to POST

### DIFF
--- a/src/libs/Jina/Generated/Jina.Models.GroundingV1GroundingPathPostResponse.Json.g.cs
+++ b/src/libs/Jina/Generated/Jina.Models.GroundingV1GroundingPathPostResponse.Json.g.cs
@@ -2,7 +2,7 @@
 
 namespace Jina
 {
-    public sealed partial class GroundingV1GroundingPathGetResponse
+    public sealed partial class GroundingV1GroundingPathPostResponse
     {
         /// <summary>
         /// Serializes the current instance to a JSON string using the provided JsonSerializerContext.
@@ -34,14 +34,14 @@ namespace Jina
         /// <summary>
         /// Deserializes a JSON string using the provided JsonSerializerContext.
         /// </summary>
-        public static global::Jina.GroundingV1GroundingPathGetResponse? FromJson(
+        public static global::Jina.GroundingV1GroundingPathPostResponse? FromJson(
             string json,
             global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
         {
             return global::System.Text.Json.JsonSerializer.Deserialize(
                 json,
-                typeof(global::Jina.GroundingV1GroundingPathGetResponse),
-                jsonSerializerContext) as global::Jina.GroundingV1GroundingPathGetResponse;
+                typeof(global::Jina.GroundingV1GroundingPathPostResponse),
+                jsonSerializerContext) as global::Jina.GroundingV1GroundingPathPostResponse;
         }
 
         /// <summary>
@@ -51,11 +51,11 @@ namespace Jina
         [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
         [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
 #endif
-        public static global::Jina.GroundingV1GroundingPathGetResponse? FromJson(
+        public static global::Jina.GroundingV1GroundingPathPostResponse? FromJson(
             string json,
             global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
         {
-            return global::System.Text.Json.JsonSerializer.Deserialize<global::Jina.GroundingV1GroundingPathGetResponse>(
+            return global::System.Text.Json.JsonSerializer.Deserialize<global::Jina.GroundingV1GroundingPathPostResponse>(
                 json,
                 jsonSerializerOptions);
         }
@@ -63,14 +63,14 @@ namespace Jina
         /// <summary>
         /// Deserializes a JSON stream using the provided JsonSerializerContext.
         /// </summary>
-        public static async global::System.Threading.Tasks.ValueTask<global::Jina.GroundingV1GroundingPathGetResponse?> FromJsonStreamAsync(
+        public static async global::System.Threading.Tasks.ValueTask<global::Jina.GroundingV1GroundingPathPostResponse?> FromJsonStreamAsync(
             global::System.IO.Stream jsonStream,
             global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
         {
             return (await global::System.Text.Json.JsonSerializer.DeserializeAsync(
                 jsonStream,
-                typeof(global::Jina.GroundingV1GroundingPathGetResponse),
-                jsonSerializerContext).ConfigureAwait(false)) as global::Jina.GroundingV1GroundingPathGetResponse;
+                typeof(global::Jina.GroundingV1GroundingPathPostResponse),
+                jsonSerializerContext).ConfigureAwait(false)) as global::Jina.GroundingV1GroundingPathPostResponse;
         }
 
         /// <summary>
@@ -80,11 +80,11 @@ namespace Jina
         [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
         [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
 #endif
-        public static global::System.Threading.Tasks.ValueTask<global::Jina.GroundingV1GroundingPathGetResponse?> FromJsonStreamAsync(
+        public static global::System.Threading.Tasks.ValueTask<global::Jina.GroundingV1GroundingPathPostResponse?> FromJsonStreamAsync(
             global::System.IO.Stream jsonStream,
             global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
         {
-            return global::System.Text.Json.JsonSerializer.DeserializeAsync<global::Jina.GroundingV1GroundingPathGetResponse?>(
+            return global::System.Text.Json.JsonSerializer.DeserializeAsync<global::Jina.GroundingV1GroundingPathPostResponse?>(
                 jsonStream,
                 jsonSerializerOptions);
         }

--- a/src/libs/Jina/Generated/Jina.Models.GroundingV1GroundingPathPostResponse.g.cs
+++ b/src/libs/Jina/Generated/Jina.Models.GroundingV1GroundingPathPostResponse.g.cs
@@ -6,7 +6,7 @@ namespace Jina
     /// <summary>
     /// 
     /// </summary>
-    public sealed partial class GroundingV1GroundingPathGetResponse
+    public sealed partial class GroundingV1GroundingPathPostResponse
     {
 
         /// <summary>

--- a/src/libs/Jina/Generated/Jina.Models.GroundingV1GroundingPathPostResponse2.Json.g.cs
+++ b/src/libs/Jina/Generated/Jina.Models.GroundingV1GroundingPathPostResponse2.Json.g.cs
@@ -2,7 +2,7 @@
 
 namespace Jina
 {
-    public sealed partial class GroundingV1GroundingPathGetResponse2
+    public sealed partial class GroundingV1GroundingPathPostResponse2
     {
         /// <summary>
         /// Serializes the current instance to a JSON string using the provided JsonSerializerContext.
@@ -34,14 +34,14 @@ namespace Jina
         /// <summary>
         /// Deserializes a JSON string using the provided JsonSerializerContext.
         /// </summary>
-        public static global::Jina.GroundingV1GroundingPathGetResponse2? FromJson(
+        public static global::Jina.GroundingV1GroundingPathPostResponse2? FromJson(
             string json,
             global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
         {
             return global::System.Text.Json.JsonSerializer.Deserialize(
                 json,
-                typeof(global::Jina.GroundingV1GroundingPathGetResponse2),
-                jsonSerializerContext) as global::Jina.GroundingV1GroundingPathGetResponse2;
+                typeof(global::Jina.GroundingV1GroundingPathPostResponse2),
+                jsonSerializerContext) as global::Jina.GroundingV1GroundingPathPostResponse2;
         }
 
         /// <summary>
@@ -51,11 +51,11 @@ namespace Jina
         [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
         [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
 #endif
-        public static global::Jina.GroundingV1GroundingPathGetResponse2? FromJson(
+        public static global::Jina.GroundingV1GroundingPathPostResponse2? FromJson(
             string json,
             global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
         {
-            return global::System.Text.Json.JsonSerializer.Deserialize<global::Jina.GroundingV1GroundingPathGetResponse2>(
+            return global::System.Text.Json.JsonSerializer.Deserialize<global::Jina.GroundingV1GroundingPathPostResponse2>(
                 json,
                 jsonSerializerOptions);
         }
@@ -63,14 +63,14 @@ namespace Jina
         /// <summary>
         /// Deserializes a JSON stream using the provided JsonSerializerContext.
         /// </summary>
-        public static async global::System.Threading.Tasks.ValueTask<global::Jina.GroundingV1GroundingPathGetResponse2?> FromJsonStreamAsync(
+        public static async global::System.Threading.Tasks.ValueTask<global::Jina.GroundingV1GroundingPathPostResponse2?> FromJsonStreamAsync(
             global::System.IO.Stream jsonStream,
             global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
         {
             return (await global::System.Text.Json.JsonSerializer.DeserializeAsync(
                 jsonStream,
-                typeof(global::Jina.GroundingV1GroundingPathGetResponse2),
-                jsonSerializerContext).ConfigureAwait(false)) as global::Jina.GroundingV1GroundingPathGetResponse2;
+                typeof(global::Jina.GroundingV1GroundingPathPostResponse2),
+                jsonSerializerContext).ConfigureAwait(false)) as global::Jina.GroundingV1GroundingPathPostResponse2;
         }
 
         /// <summary>
@@ -80,11 +80,11 @@ namespace Jina
         [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
         [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
 #endif
-        public static global::System.Threading.Tasks.ValueTask<global::Jina.GroundingV1GroundingPathGetResponse2?> FromJsonStreamAsync(
+        public static global::System.Threading.Tasks.ValueTask<global::Jina.GroundingV1GroundingPathPostResponse2?> FromJsonStreamAsync(
             global::System.IO.Stream jsonStream,
             global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
         {
-            return global::System.Text.Json.JsonSerializer.DeserializeAsync<global::Jina.GroundingV1GroundingPathGetResponse2?>(
+            return global::System.Text.Json.JsonSerializer.DeserializeAsync<global::Jina.GroundingV1GroundingPathPostResponse2?>(
                 jsonStream,
                 jsonSerializerOptions);
         }

--- a/src/libs/Jina/Generated/Jina.Models.GroundingV1GroundingPathPostResponse2.g.cs
+++ b/src/libs/Jina/Generated/Jina.Models.GroundingV1GroundingPathPostResponse2.g.cs
@@ -6,7 +6,7 @@ namespace Jina
     /// <summary>
     /// 
     /// </summary>
-    public sealed partial class GroundingV1GroundingPathGetResponse2
+    public sealed partial class GroundingV1GroundingPathPostResponse2
     {
 
         /// <summary>

--- a/src/libs/Jina/openapi.yaml
+++ b/src/libs/Jina/openapi.yaml
@@ -303,7 +303,7 @@ paths:
       tags:
         - grounding
       summary: Grounding
-      operationId: grounding_v1_grounding__path__get
+      operationId: grounding_v1_grounding__path__post
       parameters:
         - name: path
           in: path
@@ -327,7 +327,7 @@ paths:
       tags:
         - grounding
       summary: Grounding
-      operationId: grounding_v1_grounding__path__get
+      operationId: grounding_v1_grounding__path__post
       parameters:
         - name: path
           in: path


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Adjusted the grounding API specification so that endpoints now expect POST requests instead of GET, while keeping request parameters and responses unchanged. Clients using these endpoints may need to update their calls accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->