### PR TITLE
feat:Update Jina Embedding Serving API version from 0.1.110 to 0.1.111

### DIFF
--- a/src/libs/Jina/openapi.yaml
+++ b/src/libs/Jina/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.4
 info:
   title: The Jina Embedding Serving API
   description: This is the UniversalAPI to access all the Jina embedding models
-  version: 0.1.110
+  version: 0.1.111
 servers:
   - url: https://api.jina.ai/
 paths:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the Embedding Serving API version from 0.1.110 to 0.1.111.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->