### PR TITLE
feat:Set operationId serp_v1_serp__path__get on GET/POST /v1/serp/{path}

### DIFF
--- a/src/libs/Jina/Generated/Jina.Models.SerpV1SerpPathGetResponse.Json.g.cs
+++ b/src/libs/Jina/Generated/Jina.Models.SerpV1SerpPathGetResponse.Json.g.cs
@@ -2,7 +2,7 @@
 
 namespace Jina
 {
-    public sealed partial class SerpV1SerpPathPostResponse
+    public sealed partial class SerpV1SerpPathGetResponse
     {
         /// <summary>
         /// Serializes the current instance to a JSON string using the provided JsonSerializerContext.
@@ -34,14 +34,14 @@ namespace Jina
         /// <summary>
         /// Deserializes a JSON string using the provided JsonSerializerContext.
         /// </summary>
-        public static global::Jina.SerpV1SerpPathPostResponse? FromJson(
+        public static global::Jina.SerpV1SerpPathGetResponse? FromJson(
             string json,
             global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
         {
             return global::System.Text.Json.JsonSerializer.Deserialize(
                 json,
-                typeof(global::Jina.SerpV1SerpPathPostResponse),
-                jsonSerializerContext) as global::Jina.SerpV1SerpPathPostResponse;
+                typeof(global::Jina.SerpV1SerpPathGetResponse),
+                jsonSerializerContext) as global::Jina.SerpV1SerpPathGetResponse;
         }
 
         /// <summary>
@@ -51,11 +51,11 @@ namespace Jina
         [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
         [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
 #endif
-        public static global::Jina.SerpV1SerpPathPostResponse? FromJson(
+        public static global::Jina.SerpV1SerpPathGetResponse? FromJson(
             string json,
             global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
         {
-            return global::System.Text.Json.JsonSerializer.Deserialize<global::Jina.SerpV1SerpPathPostResponse>(
+            return global::System.Text.Json.JsonSerializer.Deserialize<global::Jina.SerpV1SerpPathGetResponse>(
                 json,
                 jsonSerializerOptions);
         }
@@ -63,14 +63,14 @@ namespace Jina
         /// <summary>
         /// Deserializes a JSON stream using the provided JsonSerializerContext.
         /// </summary>
-        public static async global::System.Threading.Tasks.ValueTask<global::Jina.SerpV1SerpPathPostResponse?> FromJsonStreamAsync(
+        public static async global::System.Threading.Tasks.ValueTask<global::Jina.SerpV1SerpPathGetResponse?> FromJsonStreamAsync(
             global::System.IO.Stream jsonStream,
             global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
         {
             return (await global::System.Text.Json.JsonSerializer.DeserializeAsync(
                 jsonStream,
-                typeof(global::Jina.SerpV1SerpPathPostResponse),
-                jsonSerializerContext).ConfigureAwait(false)) as global::Jina.SerpV1SerpPathPostResponse;
+                typeof(global::Jina.SerpV1SerpPathGetResponse),
+                jsonSerializerContext).ConfigureAwait(false)) as global::Jina.SerpV1SerpPathGetResponse;
         }
 
         /// <summary>
@@ -80,11 +80,11 @@ namespace Jina
         [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
         [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
 #endif
-        public static global::System.Threading.Tasks.ValueTask<global::Jina.SerpV1SerpPathPostResponse?> FromJsonStreamAsync(
+        public static global::System.Threading.Tasks.ValueTask<global::Jina.SerpV1SerpPathGetResponse?> FromJsonStreamAsync(
             global::System.IO.Stream jsonStream,
             global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
         {
-            return global::System.Text.Json.JsonSerializer.DeserializeAsync<global::Jina.SerpV1SerpPathPostResponse?>(
+            return global::System.Text.Json.JsonSerializer.DeserializeAsync<global::Jina.SerpV1SerpPathGetResponse?>(
                 jsonStream,
                 jsonSerializerOptions);
         }

--- a/src/libs/Jina/Generated/Jina.Models.SerpV1SerpPathGetResponse.g.cs
+++ b/src/libs/Jina/Generated/Jina.Models.SerpV1SerpPathGetResponse.g.cs
@@ -6,7 +6,7 @@ namespace Jina
     /// <summary>
     /// 
     /// </summary>
-    public sealed partial class SerpV1SerpPathPostResponse
+    public sealed partial class SerpV1SerpPathGetResponse
     {
 
         /// <summary>

--- a/src/libs/Jina/Generated/Jina.Models.SerpV1SerpPathGetResponse2.Json.g.cs
+++ b/src/libs/Jina/Generated/Jina.Models.SerpV1SerpPathGetResponse2.Json.g.cs
@@ -2,7 +2,7 @@
 
 namespace Jina
 {
-    public sealed partial class SerpV1SerpPathPostResponse2
+    public sealed partial class SerpV1SerpPathGetResponse2
     {
         /// <summary>
         /// Serializes the current instance to a JSON string using the provided JsonSerializerContext.
@@ -34,14 +34,14 @@ namespace Jina
         /// <summary>
         /// Deserializes a JSON string using the provided JsonSerializerContext.
         /// </summary>
-        public static global::Jina.SerpV1SerpPathPostResponse2? FromJson(
+        public static global::Jina.SerpV1SerpPathGetResponse2? FromJson(
             string json,
             global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
         {
             return global::System.Text.Json.JsonSerializer.Deserialize(
                 json,
-                typeof(global::Jina.SerpV1SerpPathPostResponse2),
-                jsonSerializerContext) as global::Jina.SerpV1SerpPathPostResponse2;
+                typeof(global::Jina.SerpV1SerpPathGetResponse2),
+                jsonSerializerContext) as global::Jina.SerpV1SerpPathGetResponse2;
         }
 
         /// <summary>
@@ -51,11 +51,11 @@ namespace Jina
         [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
         [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
 #endif
-        public static global::Jina.SerpV1SerpPathPostResponse2? FromJson(
+        public static global::Jina.SerpV1SerpPathGetResponse2? FromJson(
             string json,
             global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
         {
-            return global::System.Text.Json.JsonSerializer.Deserialize<global::Jina.SerpV1SerpPathPostResponse2>(
+            return global::System.Text.Json.JsonSerializer.Deserialize<global::Jina.SerpV1SerpPathGetResponse2>(
                 json,
                 jsonSerializerOptions);
         }
@@ -63,14 +63,14 @@ namespace Jina
         /// <summary>
         /// Deserializes a JSON stream using the provided JsonSerializerContext.
         /// </summary>
-        public static async global::System.Threading.Tasks.ValueTask<global::Jina.SerpV1SerpPathPostResponse2?> FromJsonStreamAsync(
+        public static async global::System.Threading.Tasks.ValueTask<global::Jina.SerpV1SerpPathGetResponse2?> FromJsonStreamAsync(
             global::System.IO.Stream jsonStream,
             global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
         {
             return (await global::System.Text.Json.JsonSerializer.DeserializeAsync(
                 jsonStream,
-                typeof(global::Jina.SerpV1SerpPathPostResponse2),
-                jsonSerializerContext).ConfigureAwait(false)) as global::Jina.SerpV1SerpPathPostResponse2;
+                typeof(global::Jina.SerpV1SerpPathGetResponse2),
+                jsonSerializerContext).ConfigureAwait(false)) as global::Jina.SerpV1SerpPathGetResponse2;
         }
 
         /// <summary>
@@ -80,11 +80,11 @@ namespace Jina
         [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
         [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
 #endif
-        public static global::System.Threading.Tasks.ValueTask<global::Jina.SerpV1SerpPathPostResponse2?> FromJsonStreamAsync(
+        public static global::System.Threading.Tasks.ValueTask<global::Jina.SerpV1SerpPathGetResponse2?> FromJsonStreamAsync(
             global::System.IO.Stream jsonStream,
             global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
         {
-            return global::System.Text.Json.JsonSerializer.DeserializeAsync<global::Jina.SerpV1SerpPathPostResponse2?>(
+            return global::System.Text.Json.JsonSerializer.DeserializeAsync<global::Jina.SerpV1SerpPathGetResponse2?>(
                 jsonStream,
                 jsonSerializerOptions);
         }

--- a/src/libs/Jina/Generated/Jina.Models.SerpV1SerpPathGetResponse2.g.cs
+++ b/src/libs/Jina/Generated/Jina.Models.SerpV1SerpPathGetResponse2.g.cs
@@ -6,7 +6,7 @@ namespace Jina
     /// <summary>
     /// 
     /// </summary>
-    public sealed partial class SerpV1SerpPathPostResponse2
+    public sealed partial class SerpV1SerpPathGetResponse2
     {
 
         /// <summary>

--- a/src/libs/Jina/openapi.yaml
+++ b/src/libs/Jina/openapi.yaml
@@ -303,7 +303,7 @@ paths:
       tags:
         - serp
       summary: Serp
-      operationId: serp_v1_serp__path__post
+      operationId: serp_v1_serp__path__get
       parameters:
         - name: path
           in: path
@@ -327,7 +327,7 @@ paths:
       tags:
         - serp
       summary: Serp
-      operationId: serp_v1_serp__path__post
+      operationId: serp_v1_serp__path__get
       parameters:
         - name: path
           in: path


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Updated the OpenAPI specification to correct operationId names for the GET and POST methods on /v1/serp/{path}, ensuring consistent, accurate identifiers.
  - No changes to parameters, responses, or runtime behavior; existing API usage remains unaffected.
  - Improves clarity and compatibility for client generation and API tooling that rely on operationId values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->